### PR TITLE
Use f32 for purchase_amount to match database REAL type

### DIFF
--- a/src/models/item.rs
+++ b/src/models/item.rs
@@ -11,7 +11,7 @@ pub struct Item {
     pub model_number: Option<String>,
     pub remarks: Option<String>,
     pub purchase_year: Option<i64>,
-    pub purchase_amount: Option<f64>,
+    pub purchase_amount: Option<f32>,
     pub durability_years: Option<i64>,
     pub is_depreciation_target: Option<bool>,
     pub connection_names: Option<Vec<String>>,
@@ -43,7 +43,7 @@ pub struct CreateItemRequest {
     #[validate(range(min = 1900, max = 2100))]
     pub purchase_year: Option<i64>,
 
-    pub purchase_amount: Option<f64>,
+    pub purchase_amount: Option<f32>,
 
     #[validate(range(min = 1, max = 100))]
     pub durability_years: Option<i64>,
@@ -82,7 +82,7 @@ pub struct UpdateItemRequest {
     #[validate(range(min = 1900, max = 2100))]
     pub purchase_year: Option<i64>,
 
-    pub purchase_amount: Option<f64>,
+    pub purchase_amount: Option<f32>,
 
     #[validate(range(min = 1, max = 100))]
     pub durability_years: Option<i64>,


### PR DESCRIPTION
## Summary
- store item purchase_amount as `f32` instead of `f64`

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68ba974ac808832bba3837a4fb1d8615