### PR TITLE
備考欄の空欄バグのバックエンド側修正

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,7 +39,7 @@ jobs:
           type=ref,event=pr
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
-          type=sha,prefix={{branch}}-
+          type=sha,prefix=sha-
           type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Set up Docker Buildx

--- a/src/models/item.rs
+++ b/src/models/item.rs
@@ -1,5 +1,5 @@
 use chrono::{DateTime, Utc};
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 use uuid::Uuid;
 use validator::Validate;
 
@@ -77,7 +77,8 @@ pub struct UpdateItemRequest {
     #[validate(length(max = 255))]
     pub model_number: Option<String>,
 
-    pub remarks: Option<String>,
+    #[serde(default, deserialize_with = "deserialize_optional_nullable_string")]
+    pub remarks: Option<Option<String>>,
 
     #[validate(range(min = 1900, max = 2100))]
     pub purchase_year: Option<i32>,
@@ -109,10 +110,39 @@ pub struct UpdateItemRequest {
     pub image_url: Option<String>,
 }
 
+fn deserialize_optional_nullable_string<'de, D>(
+    deserializer: D,
+) -> Result<Option<Option<String>>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer).map(Some)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ItemsListResponse {
     pub items: Vec<Item>,
     pub total: i64,
     pub page: u32,
     pub per_page: u32,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::UpdateItemRequest;
+
+    #[test]
+    fn update_item_request_distinguishes_missing_null_and_string_remarks() {
+        let missing: UpdateItemRequest = serde_json::from_str("{}").unwrap();
+        assert_eq!(missing.remarks, None);
+
+        let null: UpdateItemRequest = serde_json::from_str(r#"{"remarks":null}"#).unwrap();
+        assert_eq!(null.remarks, Some(None));
+
+        let empty: UpdateItemRequest = serde_json::from_str(r#"{"remarks":""}"#).unwrap();
+        assert_eq!(empty.remarks, Some(Some(String::new())));
+
+        let value: UpdateItemRequest = serde_json::from_str(r#"{"remarks":"note"}"#).unwrap();
+        assert_eq!(value.remarks, Some(Some("note".to_string())));
+    }
 }

--- a/src/services/item_service.rs
+++ b/src/services/item_service.rs
@@ -710,14 +710,34 @@ impl ItemService {
     }
 
     pub async fn update_item(&self, id: Uuid, req: UpdateItemRequest) -> AppResult<Item> {
+        let UpdateItemRequest {
+            name,
+            label_id,
+            model_number,
+            remarks,
+            purchase_year,
+            purchase_amount,
+            durability_years,
+            is_depreciation_target,
+            connection_names,
+            cable_color_pattern,
+            storage_location,
+            container_id,
+            storage_type,
+            is_on_loan: _,
+            qr_code_type,
+            is_disposed: _,
+            image_url,
+        } = req;
+        let remarks = remarks.map(|value| value.unwrap_or_default());
+
         match &self.db {
             DatabasePool::Postgres(pool) => {
                 // まず物品が存在するかチェック
                 let _existing_item = self.get_item(id).await?;
 
                 // JSON配列フィールドをシリアライズ
-                let connection_names_json = req
-                    .connection_names
+                let connection_names_json = connection_names
                     .as_ref()
                     .map(serde_json::to_string)
                     .transpose()
@@ -728,8 +748,7 @@ impl ItemService {
                         ))
                     })?;
 
-                let cable_color_pattern_json = req
-                    .cable_color_pattern
+                let cable_color_pattern_json = cable_color_pattern
                     .as_ref()
                     .map(serde_json::to_string)
                     .transpose()
@@ -739,8 +758,6 @@ impl ItemService {
                             e
                         ))
                     })?;
-
-                let storage_location = req.storage_location;
 
                 let now = chrono::Utc::now();
 
@@ -767,21 +784,21 @@ impl ItemService {
                     "#,
                 )
                 .bind(id)
-                .bind(&req.name)
-                .bind(&req.label_id)
-                .bind(&req.model_number)
-                .bind(&req.remarks)
-                .bind(req.purchase_year)
-                .bind(req.purchase_amount)
-                .bind(req.durability_years)
-                .bind(req.is_depreciation_target)
+                .bind(&name)
+                .bind(&label_id)
+                .bind(&model_number)
+                .bind(&remarks)
+                .bind(purchase_year)
+                .bind(purchase_amount)
+                .bind(durability_years)
+                .bind(is_depreciation_target)
                 .bind(&connection_names_json)
                 .bind(&cable_color_pattern_json)
                 .bind(&storage_location)
-                .bind(&req.container_id)
-                .bind(&req.storage_type)
-                .bind(&req.qr_code_type)
-                .bind(&req.image_url)
+                .bind(&container_id)
+                .bind(&storage_type)
+                .bind(&qr_code_type)
+                .bind(&image_url)
                 .bind(now)
                 .execute(pool)
                 .await?;
@@ -794,8 +811,7 @@ impl ItemService {
                 let _existing_item = self.get_item(id).await?;
 
                 // JSON配列フィールドをシリアライズ
-                let connection_names_json = req
-                    .connection_names
+                let connection_names_json = connection_names
                     .as_ref()
                     .map(serde_json::to_string)
                     .transpose()
@@ -806,8 +822,7 @@ impl ItemService {
                         ))
                     })?;
 
-                let cable_color_pattern_json = req
-                    .cable_color_pattern
+                let cable_color_pattern_json = cable_color_pattern
                     .as_ref()
                     .map(serde_json::to_string)
                     .transpose()
@@ -817,8 +832,6 @@ impl ItemService {
                             e
                         ))
                     })?;
-
-                let storage_location = req.storage_location;
 
                 let now = chrono::Utc::now();
                 let id_str = id.to_string();
@@ -846,21 +859,21 @@ impl ItemService {
                     "#,
                 )
                 .bind(id_str)
-                .bind(req.name)
-                .bind(req.label_id)
-                .bind(req.model_number)
-                .bind(req.remarks)
-                .bind(req.purchase_year)
-                .bind(req.purchase_amount)
-                .bind(req.durability_years)
-                .bind(req.is_depreciation_target)
+                .bind(name)
+                .bind(label_id)
+                .bind(model_number)
+                .bind(remarks)
+                .bind(purchase_year)
+                .bind(purchase_amount)
+                .bind(durability_years)
+                .bind(is_depreciation_target)
                 .bind(connection_names_json)
                 .bind(cable_color_pattern_json)
                 .bind(storage_location)
-                .bind(req.container_id)
-                .bind(req.storage_type)
-                .bind(req.qr_code_type)
-                .bind(req.image_url)
+                .bind(container_id)
+                .bind(storage_type)
+                .bind(qr_code_type)
+                .bind(image_url)
                 .bind(now)
                 .execute(pool)
                 .await?;


### PR DESCRIPTION
備考欄を空欄で更新した際にフロントから送られてくる null を、サーバー側で空文字列に変換して DB に保存するようにした